### PR TITLE
Fix 'Thread object has no attribute _children' error on my machine.

### DIFF
--- a/spartan/worker.py
+++ b/spartan/worker.py
@@ -32,7 +32,7 @@ class Worker(object):
     
     self._lock = threading.Lock()
     
-    #fix the "no _children attribute" exception.
+    #Patch to fix buggy assumption by multiprocessing library  
     if not hasattr(threading.current_thread(), "_children"):
       threading.current_thread()._children = weakref.WeakKeyDictionary()
     


### PR DESCRIPTION
While I ran spartan on my desktop machine. It reports: 
"AttributeError: 'Thread' object has no attribute '_children'".

I guess it's because the version of library. Fixed this by adding two lines of code: 
"
if not hasattr(threading.current_thread(), "_children"):
 threading.current_thread()._children = weakref.WeakKeyDictionary()
"
