### PR TITLE
fix rpc server._handler = None error by using Conditional variable

### DIFF
--- a/spartan/rpc/common.py
+++ b/spartan/rpc/common.py
@@ -288,7 +288,7 @@ class Server(object):
   def serve_nonblock(self):
 #    util.log_info('Running.')
     self._running = True
-    self._socket.start_listening()
+    self._socket.listen()
 
   def register_object(self, obj):
     for name in dir(obj):

--- a/spartan/rpc/zeromq.py
+++ b/spartan/rpc/zeromq.py
@@ -129,12 +129,12 @@ class Socket(SocketBase):
 class ServerSocket(Socket):
   def __init__(self, ctx, sock_type, hostport):
     Socket.__init__(self, ctx, sock_type, hostport)
-    self.started_listen = False
+    self._listen = False
     self.addr = hostport
     self.bind()
   
-  def start_listening(self):
-    self.started_listen = True
+  def listen(self):
+    self._listen = True
 
   def send(self, msg):
     '''Send ``msg`` to a remote client.
@@ -162,7 +162,7 @@ class ServerSocket(Socket):
     poller().add(self, zmq.POLLIN)
 
   def handle_read(self, socket):
-    if self.started_listen == False:
+    if self._listen == False:
       #ignore the message if it's not been started.
       return
 


### PR DESCRIPTION
While I ran spartan, sometimes I got the error message like
"
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 808, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 761, in run
    self.__target(_self.__args, *_self.__kwargs)
  File "/home/yisheng/workplace/spartan/spartan/rpc/zeromq.py", line 261, in _run
    if event & zmq.POLLIN: s.handle_read(s)
  File "/home/yisheng/workplace/spartan/spartan/rpc/zeromq.py", line 170, in handle_read
    self._handler(stub_socket)
AttributeError: 'ServerSocket' object has no attribute '_handler'
"

It's rare, but it does happen. The problem is in rpc library.
Specifically, in rpc, we would create socket first, then we pass socket to Server and Server will register its handle_read function to socket.

Before the registration, the poller thread gets started. And if the message arrives at this time, since the handler function has not been registered yet, it will report this error.

Simply fix this by adding a condition variable, the bug never appears again.
