### PR TITLE
Fix broadcasting.

### DIFF
--- a/spartan/expr/map.py
+++ b/spartan/expr/map.py
@@ -72,6 +72,9 @@ class MapExpr(Expr):
     largest = distarray.largest_value(vals)
 
     children = dict(zip(keys, vals))
+    for k, child in children.iteritems():
+      util.log_debug('Map children: %s', child)
+
     #util.log_info('Mapping %s over %d inputs; largest = %s', op, len(children), largest.shape)
 
     return largest.map_to_array(


### PR DESCRIPTION
The wrong dimensions were being trimmed when fetching from a
broadcast array.  If input matrices happened to be square, then
this would trigger the error.
