### PR TITLE
Fix the serialization bug in some test cases

### DIFF
--- a/spartan/rpc/serialization.pyx
+++ b/spartan/rpc/serialization.pyx
@@ -243,7 +243,7 @@ cpdef read_function(f):
 cpdef _write(obj, f):
   if obj is None:
     f.write('E')
-  elif isinstance(obj, np.ndarray):
+  elif isinstance(obj, np.ndarray) and not np.ma.isMaskedArray(obj):
     # sparse arrays will fail the np.ndarray check and are handled by cPickle
     f.write('N')
     if not obj.flags['C_CONTIGUOUS']:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,47 @@
+from spartan import expr, blob_ctx
+from spartan.rpc import common, serialization
+from spartan.util import Assert
+import numpy as np
+import scipy.sparse as sp
+import test_common
+
+ARRAY_SIZE=(10,10)
+
+class TestSerialization(test_common.ClusterTest):
+  def test_dense_array(self):
+    a = np.ones(ARRAY_SIZE)
+    buf = common.serialize(a)
+    f = serialization.Reader(buf)
+    b = common.read(f)
+    Assert.all_eq(a, b)
+  
+  def test_noncontiguous_array(self):
+    t = np.ones(ARRAY_SIZE)
+    a = t[3:7, 3:7]
+    buf = common.serialize(a)
+    f = serialization.Reader(buf)
+    b = common.read(f)
+    Assert.all_eq(a, b)
+     
+  def test_scalar(self):
+    a = np.asarray(10).reshape(())
+    buf = common.serialize(a)
+    f = serialization.Reader(buf)
+    b = common.read(f)
+    Assert.all_eq(a, b)
+  
+  def test_sparse(self):
+    a = sp.coo_matrix(ARRAY_SIZE, dtype=np.int32)
+    buf = common.serialize(a)
+    f = serialization.Reader(buf)
+    b = common.read(f)
+    Assert.all_eq(a.todense(), b.todense())
+    
+  def test_mask_array(self):
+    a = np.ma.masked_all(ARRAY_SIZE, np.int32)
+    a[5,5] = 10
+    buf = common.serialize(a)
+    f = serialization.Reader(buf)
+    b = common.read(f)
+    Assert.all_eq(a, b)
+    Assert.isinstance(b, np.ma.MaskedArray)


### PR DESCRIPTION
The bug is due to the np.ascontiguousarray. When the reduce_mapper output a scalar, it will use np.asarray to format it as a () shape np array. However, when we call np.ascontiguousarray(), the data change to (1,) shape np array. Therefore, the next time when we fetch the scalar from the tile, the check len(self.data.shape) == 0 will fail and return a mask array.
       In [1]: x = np.asarray(10).reshape(()) 
       In [2]: x  
     Out[2]: array(10)
       In [3]: np.ascontiguousarray(x)
     Out[3]: array([10])
