### PR TITLE
use broadcast send in rpc

### DIFF
--- a/spartan/rpc/common.pyx
+++ b/spartan/rpc/common.pyx
@@ -567,6 +567,6 @@ def forall(clients, method, request, timeout=None):
   
   with TIMER.master_loop:
     for c in clients:
-      getattr(c, method).call_raw(data, future=fgroup)
+      c.send_raw(data=data, future=fgroup)
   
   return fgroup


### PR DESCRIPTION
add broadcast send in rpc. So we can only serialize the header and body of the message once and create only on condition object for forall function.

test on run empty map kernel:
                     before(ms)   after
8 workers:     371ms         326ms
16 workers:  488ms          402ms
32 workers:  765ms          575ms
