### PR TITLE
init np.random.seed in every worker

### DIFF
--- a/spartan/worker.py
+++ b/spartan/worker.py
@@ -49,8 +49,10 @@ class Worker(object):
       _blobs (dict): Mapping from tile id to tile.
   '''
   def __init__(self, master):
-    # Initialize the seed of numpy. 
-    # So every worker won't generate the same random numbers.
+    # Reseed the Numpy random number state.
+    # 
+    # The default initialization results in all worker processes on the machine having the 
+    # same random seed.
     np.random.seed(seed=os.getpid())
 
     self.id = -1


### PR DESCRIPTION
When I used spartan.randn to generate data in SVD, the result is not accurate. But using numpy is fine.
It turns out is that all the workers generate the same random data in the array since the default seed of numpy random generator comes from the computer clock.
