### PR TITLE
Add flag for enabling/disabling expression caching.

### DIFF
--- a/spartan/core.pyx
+++ b/spartan/core.pyx
@@ -95,6 +95,9 @@ class Message(Node):
   def __getstate__(self):
     return self.__dict__
 
+  def __repr__(self):
+    return self.debug_str()
+
 
 
 class RegisterReq(Message):

--- a/spartan/expr/base.py
+++ b/spartan/expr/base.py
@@ -14,9 +14,11 @@ from ..node import Node, indent
 from .. import blob_ctx, node, util
 from ..util import Assert, copy_docstring
 from ..array import distarray
-from ..config import FLAGS
+from ..config import FLAGS, BoolFlag
 from ..rpc import TimeoutException
 from traits.api import Any, Instance, Int, PythonValue
+
+FLAGS.add(BoolFlag('opt_expression_cache', True, 'Enable expression caching.'))
 
 class NotShapeable(Exception):
   '''
@@ -177,6 +179,9 @@ class Expr(Node):
     If a cached value is not available, or the cached array is
     invalid (missing tiles), returns None. 
     '''
+    if not FLAGS.optimization or not FLAGS.opt_expression_cache:
+      return None
+
     result = eval_cache.get(self.expr_id)
     if result is not None and len(result.bad_tiles) == 0:
       return result

--- a/spartan/rpc/common.py
+++ b/spartan/rpc/common.py
@@ -52,7 +52,7 @@ def serialize_to(obj, writer):
   pos = writer.tell()
   try:
     cPickle.dump(obj, writer, -1)
-  except (pickle.PicklingError, PickleError, TypeError):
+  except (ImportError, pickle.PicklingError, PickleError, TypeError):
     writer.seek(pos)
     cloudpickle.dump(obj, writer, -1)
     

--- a/spartan/worker.py
+++ b/spartan/worker.py
@@ -275,7 +275,9 @@ class Worker(object):
     :param handle: `PendingRequest`
     
     '''
-    util.log_info('Shutdown worker %d (profile? %d)', self.id, FLAGS.profile_worker)
+    if FLAGS.profile_worker:
+        util.log_info('Working shutting down... writing profile.', self.id, FLAGS.profile_worker)
+
     if FLAGS.profile_worker:
       try:
         os.system('mkdir -p ./_worker_profiles/')
@@ -310,12 +312,12 @@ class Worker(object):
       try:
         future.wait()
       except TimeoutException:
-        util.log_info("Exit due to heartbeat message timeout.")
+        util.log_error("Exit due to heartbeat message timeout.")
         sys.exit(0)
 
       last_heartbeat = time.time()
 
-    util.log_info('Worker shutdown.  Exiting.')
+    util.log_debug('Worker shutdown.  Exiting.')
 
 
 def _start_worker(master, local_id):


### PR DESCRIPTION
This also checks the global optimization flag.

Additionally, reduce some logging and catch import errors
when serializing.
