### PR TITLE
Add raise_exception helper assertion to Assert

### DIFF
--- a/spartan/util.py
+++ b/spartan/util.py
@@ -333,6 +333,14 @@ class Assert(object):
   def not_null(expr):
     assert expr is not None, expr
 
+  @staticmethod
+  def raises_exception(exception, function, *args, **kwargs):
+    try:
+      function(*args, **kwargs)
+    except exception:
+      pass
+    assert False, '%s expected, no error was raised.' % exception.__name__
+
 
 def trace_fn(fn):
   '''Function decorator: log on entry and exit to ``fn``.'''


### PR DESCRIPTION
Calls the function with the passed args and kwargs. If the function does not raise the exception or raises a different one, it asserts False.
