### PR TITLE
Add len operator overloading to distarray.

### DIFF
--- a/spartan/array/distarray.py
+++ b/spartan/array/distarray.py
@@ -146,6 +146,10 @@ class DistArray(object):
     '''
     return np.prod(self.shape)
 
+  def __len__(self):
+    ''' Alias of real_size(self). '''
+    return self.real_size()
+
   def __repr__(self):
     return '%s(id=%s, shape=%s, dtype=%s)' % (self.__class__.__name__, id(self), self.shape, self.dtype)
   


### PR DESCRIPTION
**len**(self) is just an alias to real_size(self), but allows the
user to use standard Python syntax.
