### PR TITLE
Add appdirs.user_config_dir support.

### DIFF
--- a/spartan/array/distarray.py
+++ b/spartan/array/distarray.py
@@ -4,6 +4,7 @@ import itertools
 import collections
 import traceback
 
+import appdirs
 import scipy.sparse
 import numpy as np
 
@@ -455,7 +456,10 @@ def create(shape,
   elif FLAGS.tile_assignment_strategy == 'static':
     all_extents = list(extents.iterkeys())
     all_extents.sort()
-    map_file = appdirs.user_data_dir('Spartan', 'rjpower.org') + '/tiles_map'
+    if getattr(appdirs, 'user_config_dir'):  # user_config_dir new to v1.3.0
+      map_file = appdirs.user_config_dir('spartan') + '/tiles_map'
+    else:
+      map_file = appdirs.user_data_dir('spartan') + '/tiles_map'
     with open(map_file) as fp:
       for ex in all_extents:
         worker = int(fp.readline().strip())

--- a/spartan/config.py
+++ b/spartan/config.py
@@ -165,7 +165,10 @@ def parse(argv):
 
   FLAGS._parsed = True
 
-  config_file = appdirs.user_data_dir('Spartan', 'rjpower.org') + '/spartan.ini'
+  if getattr(appdirs, 'user_config_dir'):  # user_config_dir new to v1.3.0
+    config_file = appdirs.user_config_dir('spartan') + '/spartan.ini'
+  else:
+    config_file = appdirs.user_data_dir('spartan') + '/spartan.ini'
   config_dir = os.path.dirname(config_file)
   if not os.path.exists(config_dir):
     try:


### PR DESCRIPTION
In the latest appdirs builds, `user_data_dir``has moved from
~/.config/spartan to ~/.local/share/spartan. A`user_config_dir` command
was added for the original behavior (~/.config/spartan).

If the user is using the latest appdirs (v1.3.0 and up), then use
`user_config_dir`; otherwise, fall back on `user_data_dir`.
