### PR TITLE
fix cPickle.dump simple function error

### DIFF
--- a/spartan/expr/optimize.py
+++ b/spartan/expr/optimize.py
@@ -206,6 +206,7 @@ class ReduceMapFusion(OptimizePass):
                      dtype_fn=expr.dtype_fn,
                      accumulate_fn=expr.accumulate_fn,
                      op=combined_op,
+                     tile_hint=expr.tile_hint,
                      trace=trace)
 
 
@@ -789,7 +790,7 @@ class AutomaticTiling(OptimizePass):
     # give expr the best tiling hint
     for node_id in nodes:
       node = self.nodes[node_id]
-      #print node_id, 'tiling:', node.tiling
+      #print node.expr.typename(), 'tiling:', node.tiling
       if node.tiling >= 0:
         _tiled_exprlist[node.expr.expr_id] = node.tiling
         if node.expr.typename() in ['NdArrayExpr', 'ReduceExpr', 'DotExpr'] and len(node.expr.shape) > 0:

--- a/spartan/rpc/common.py
+++ b/spartan/rpc/common.py
@@ -22,6 +22,7 @@ from . import serialization
 from traits.api import PythonValue
 from . import serialization, serialization_buffer
 from spartan.util import TIMER
+from ..core import RunKernelReq
 
 NO_RESULT = object()
 DEFAULT_TIMEOUT = 60
@@ -49,6 +50,10 @@ class Group(tuple):
   pass
 
 def serialize_to(obj, writer):
+  if isinstance(obj, RunKernelReq): 
+    cloudpickle.dump(obj, writer, -1)
+    return
+
   pos = writer.tell()
   try:
     cPickle.dump(obj, writer, -1)
@@ -57,6 +62,9 @@ def serialize_to(obj, writer):
     cloudpickle.dump(obj, writer, -1)
     
 def serialize(obj):
+  if isinstance(obj, RunKernelReq): 
+    return cloudpickle.dump(obj, -1)
+
   try:
     return cPickle.dumps(obj, -1)
   except (pickle.PicklingError, PickleError, TypeError):


### PR DESCRIPTION
let spartan be able to use ipython defined simple function as map, reduce and
shuffle parameters
