### PR TITLE
Fix the bug that automatical tiling algorithm can't handle AsArray if the val is a np.ndarray.

### DIFF
--- a/spartan/expr/optimize.py
+++ b/spartan/expr/optimize.py
@@ -113,7 +113,7 @@ def merge_var(children, child_to_var, k, v):
 
 class MapMapFusion(OptimizePass):
   '''Fold sequences of Map operations together.
-
+  
   map(f, map(g, map(h, x))) -> map(f . g . h, x)
   '''
   name = 'map_fusion'
@@ -179,7 +179,7 @@ class ReduceMapFusion(OptimizePass):
     for v in old_children:
       if not isinstance(v, (MapExpr, ParakeetExpr)) or id(v) in _not_idempotent_list:
         return expr.visit(self)
-
+      
     combined_op = LocalReduceExpr(fn=expr.op.fn,
                                   kw=expr.op.kw,
                                   deps=[expr.op.deps[0]])
@@ -344,9 +344,9 @@ class ParakeetGeneration(OptimizePass):
                                 op=local.ParakeetExpr(source=source,  deps=expr.op.deps),
                                 children=ListExpr(vals = new_children),
                                 child_to_var=expr.child_to_var)
-
+      
       if id(expr) in _not_idempotent_list: _not_idempotent_list.add(id(parakeet_expr))
-
+      
       return parakeet_expr
     except local.CodegenException:
       util.log_info('Failed to convert to parakeet.')
@@ -359,7 +359,7 @@ class ParakeetGeneration(OptimizePass):
 #     # if we've already converted this to parakeet, stop now
 #     if isinstance(expr.op, local.ParakeetExpr):
 #       return expr.visit(self)
-#
+# 
 #     try:
 #       source = codegen(expr.op)
 #       return expr_like(expr,
@@ -444,14 +444,14 @@ class AutomaticTiling(OptimizePass):
   Automatically partition all the arrays.
   We build a min cost max flow DAG for the expr graph, where the cost is the communication cost
   through network. We estimate the cost according to the behavior of each expr. For _builtin_ expr
-  and simple map and reduce expr, we can easily estimate the cost. However, for the user defined shuffle
+  and simple map and reduce expr, we can easily estimate the cost. However, for the user defined shuffle 
   expr, we can only guess the cost or let users define the cost for us.
-
+  
   All Exprs:
     [Val, AsArray, DistArray]: Already partitioned array
     [NdArrayExpr]: new array needs to be partitioned
     CollectionExpr([DictExpr, ListExpr, TupleExpr]): self.vals
-
+    
     [MapExpr]: self.children
     [ReduceExpr]: self.children
     [ShuffleExpr]: self.array, self.fn_kw
@@ -459,14 +459,14 @@ class AutomaticTiling(OptimizePass):
 
     [SliceExpr, FilterExpr, CheckpointExpr, TileOpExpr]: self.src or self.array
     [WriteArrayExpr]: self.array, self.data
-
-    [TransposeExpr, ReshapeExpr]: self.array
+  
+    [TransposeExpr, ReshapeExpr]: self.array  
   '''
-
+  
   name = 'auto_tiling'
   node_type = namedtuple('node_type', ['expr', 'tiling', 'children', 'parents'])
   inited = False
-
+  
   def init(self, expr):
     self.cur_node_id = 1
     self.edges = {}
@@ -475,40 +475,40 @@ class AutomaticTiling(OptimizePass):
     self.split_nodes = {}
     self.init_expr = id(expr)
     self.inited = True
-
+      
   def add_edge(self, edge_from, edge_to, edge_cost=0):
     #util.log_warn('add_edge:%d %d cost:%d', edge_from, edge_to, edge_cost)
     self.edges[(edge_from, edge_to)] = edge_cost
     self.nodes[edge_from].parents.append(edge_to)
     self.nodes[edge_to].children.append(edge_from)
-
+      
   def remove_edge(self, edge_from, edge_to):
     del self.edges[(edge_from, edge_to)]
     self.nodes[edge_from].parents.remove(edge_to)
     self.nodes[edge_to].children.remove(edge_from)
-
+  
   def add_split_nodes(self, node1, node2):
     self.split_nodes[node1] = node2
-    self.split_nodes[node2] = node1
-
+    self.split_nodes[node2] = node1  
+  
   def visit_children(self, children, except_child = None):
     child_ids = []
     for child in children:
       if isinstance(child, (Expr, DistArray)) and id(child) != id(except_child):
-        child_ids.extend(self.visit_default(child))
-    return child_ids
-
+        child_ids.extend(self.visit_default(child))          
+    return child_ids 
+  
   def visit_NdArrayExpr(self, expr):
     # new array need to be partitioned
     if len(expr.shape) > 1 and expr.shape[1] > 1:
       self.nodes[self.cur_node_id] = self.node_type([expr], 0, [], [])
       self.add_edge(0, self.cur_node_id, 0)
-      self.cur_node_id += 1
-
+      self.cur_node_id += 1    
+      
       self.nodes[self.cur_node_id] = self.node_type([expr], 1, [], [])
       self.add_edge(0, self.cur_node_id, 0)
       self.cur_node_id += 1
-
+      
       self.add_split_nodes(self.cur_node_id - 2, self.cur_node_id - 1)
       return [self.cur_node_id - 2, self.cur_node_id - 1]
     else:
@@ -516,15 +516,15 @@ class AutomaticTiling(OptimizePass):
       self.add_edge(0, self.cur_node_id, 0)
       self.cur_node_id += 1
       return [self.cur_node_id - 1]
-
+  
   def visit_MapExpr(self, expr):
     largest = max(expr.children.vals, key=lambda v: reduce(operator.mul, v.shape, 1))
-
-    child_ids = self.visit_children([largest])
+    
+    child_ids = self.visit_children([largest])      
     other_child_ids = self.visit_children(expr.children.vals, largest)
-
+    
     # one input map, reuse child expr
-    if len(other_child_ids) == 0:
+    if len(other_child_ids) == 0: 
       for child_id in child_ids: self.nodes[child_id].expr.append(expr)
       return child_ids
 
@@ -535,23 +535,23 @@ class AutomaticTiling(OptimizePass):
     else:
       tiling_types = (self.nodes[child_ids[0]].tiling,)
       expr_node_ids = [self.cur_node_id]
-
+     
     for i in xrange(len(tiling_types)):
       tiling_type = tiling_types[i]
       self.nodes[self.cur_node_id] = self.node_type([expr], tiling_type, [], [])
       self.add_edge(child_ids[i], self.cur_node_id, 0)
-
+      
       for child_id in other_child_ids:
         child = self.nodes[child_id]
         e_cost = reduce(operator.mul, child.expr[0].shape, 1) if child.tiling != tiling_type else 0
-        self.add_edge(child_id, self.cur_node_id, e_cost)
-      self.cur_node_id += 1
-
+        self.add_edge(child_id, self.cur_node_id, e_cost)       
+      self.cur_node_id += 1 
+        
     return expr_node_ids
-
+      
   def visit_ReduceExpr(self, expr):
     child_ids = self.visit_children(expr.children.vals)
-    cost = reduce(operator.mul, expr.shape, 1)
+    cost = reduce(operator.mul, expr.shape, 1)  
     self.nodes[self.cur_node_id] = self.node_type([expr], 0, [], [])
     for child_id in child_ids:
       child = self.nodes[child_id]
@@ -559,7 +559,7 @@ class AutomaticTiling(OptimizePass):
       self.add_edge(child_id, self.cur_node_id, e_cost)
     self.cur_node_id += 1
     return [self.cur_node_id - 1]
-
+  
   def visit_ShuffleExpr(self, expr):
     for child in expr.fn_kw.itervalues():
       if isinstance(child, (Expr, DistArray)) and hash(child) not in expr.cost_hint:
@@ -571,7 +571,7 @@ class AutomaticTiling(OptimizePass):
 
     child_ids = self.visit_children([expr.array])
     other_child_ids = self.visit_children(expr.fn_kw.itervalues())
-
+    
     # calc the copy cost
     if len(other_child_ids) == 0:
       expr_node_ids = child_ids
@@ -583,23 +583,23 @@ class AutomaticTiling(OptimizePass):
       else:
         tiling_types = (self.nodes[child_ids[0]].tiling,)
         expr_node_ids = [self.cur_node_id]
-
+        
       for i in xrange(len(tiling_types)):
         tiling_type = tiling_types[i]
         self.nodes[self.cur_node_id] = self.node_type([expr], tiling_type, [], [])
         self.add_edge(child_ids[i], self.cur_node_id, 0)
-
+        
         for child in expr.fn_kw.itervalues():
           if isinstance(child, (Expr, DistArray)):
             for child_id in self.expr_to_nodes[hash(child)]:
-              self.add_edge(child_id, self.cur_node_id, expr.cost_hint[hash(child)]['%d%d'%(self.nodes[child_id].tiling, tiling_type)])
+              self.add_edge(child_id, self.cur_node_id, expr.cost_hint[hash(child)]['%d%d'%(self.nodes[child_id].tiling, tiling_type)])       
         self.cur_node_id += 1
 
     # calculate update cost
     if expr.target is not None:
       other_child_ids = expr_node_ids
       child_ids = self.visit_children([expr.target])
-
+      
       if child_ids[0] in self.split_nodes:
         tiling_types = (0, 1)
         self.add_split_nodes(self.cur_node_id, self.cur_node_id + 1)
@@ -612,17 +612,17 @@ class AutomaticTiling(OptimizePass):
         tiling_type = tiling_types[i]
         self.nodes[self.cur_node_id] = self.node_type([expr], tiling_type, [], [])
         self.add_edge(child_ids[i], self.cur_node_id, 0)
-
+        
         for child_id in other_child_ids:
-          self.add_edge(child_id, self.cur_node_id, expr.cost_hint[hash(expr.target)]['%d%d'%(self.nodes[child_id].tiling, tiling_type)])
+          self.add_edge(child_id, self.cur_node_id, expr.cost_hint[hash(expr.target)]['%d%d'%(self.nodes[child_id].tiling, tiling_type)])       
         self.cur_node_id += 1
       return expr_node_ids
-
-    if expr.shape == expr.array.shape or len(other_child_ids) > 0:
+    
+    if expr.shape == expr.array.shape or len(other_child_ids) > 0: 
       if len(other_child_ids) == 0:
         for child_id in expr_node_ids: self.nodes[child_id].expr.append(expr)
       return expr_node_ids
-
+    
     # fix result tiling
     if len(expr.shape) <= 1 or 1 in expr.shape[:2]:
       tiling_type = 0 if len(expr.shape) <= 1 else 1 - expr.shape.index(1)
@@ -640,7 +640,7 @@ class AutomaticTiling(OptimizePass):
         self.cur_node_id += 1
       if len(expr_node_ids) > 1: self.add_split_nodes(*expr_node_ids)
     return expr_node_ids
-
+    
   def visit_DotExpr(self, expr):
     child_ids = self.visit_children([expr.matrix_a])
     other_child_ids = self.visit_children([expr.matrix_b])
@@ -654,29 +654,29 @@ class AutomaticTiling(OptimizePass):
       else:
         tiling_types = (self.nodes[child_ids[0]].tiling,)
         expr_node_ids = [self.cur_node_id]
-
+        
       for i in xrange(len(tiling_types)):
         tiling_type = tiling_types[i]
         self.nodes[self.cur_node_id] = self.node_type([expr], tiling_type, [], [])
         self.add_edge(child_ids[i], self.cur_node_id, 0)
-
+        
         for child_id in other_child_ids:
           child = self.nodes[child_id]
           e_cost = reduce(operator.mul, child.expr[0].shape, 1) if tiling_type == 0 or child.tiling == tiling_type else 0
-          self.add_edge(child_id, self.cur_node_id, e_cost)
+          self.add_edge(child_id, self.cur_node_id, e_cost)       
         self.cur_node_id += 1
-
+      
       child_ids = expr_node_ids
-
-    # calc update cost
+      
+    # calc update cost  
     if len(expr.shape) == 1 or expr.shape[1] == 1:
       tiling_types = (0,)
       expr_node_ids = [self.cur_node_id]
     else:
-      tiling_types = (0, 1)
+      tiling_types = (0, 1) 
       self.add_split_nodes(self.cur_node_id, self.cur_node_id + 1)
       expr_node_ids = [self.cur_node_id, self.cur_node_id + 1]
-
+    
     for tiling_type in tiling_types:
       self.nodes[self.cur_node_id] = self.node_type([expr], tiling_type, [], [])
       for child_id in child_ids:
@@ -684,7 +684,7 @@ class AutomaticTiling(OptimizePass):
         self.add_edge(child_id, self.cur_node_id, e_cost)
       self.cur_node_id += 1
     return expr_node_ids
-
+  
   def visit_WriteArrayExpr(self, expr):
     child_ids = self.visit_children([expr.array])
     if isinstance(expr.data, (Expr, DistArray)):
@@ -696,21 +696,21 @@ class AutomaticTiling(OptimizePass):
       else:
         tiling_types = (self.nodes[child_ids[0]].tiling,)
         expr_node_ids = [self.cur_node_id]
-
+        
       for i in xrange(len(tiling_types)):
         self.nodes[self.cur_node_id] = self.node_type([expr], tiling_types[i], [], [])
         self.add_edge(child_ids[i], self.cur_node_id, 0)
-
+        
         for child_id in data_child_ids:
           child = self.nodes[child_id]
           e_cost = reduce(operator.mul, child.expr[0].shape, 1) if child.tiling != tiling_types[i] else 0
-          self.add_edge(child_id, self.cur_node_id, e_cost)
+          self.add_edge(child_id, self.cur_node_id, e_cost)       
         self.cur_node_id += 1
       return expr_node_ids
 
     for child_id in child_ids: self.nodes[child_id].expr.append(expr)
-    return child_ids
-
+    return child_ids 
+  
   def visit_aligned_nodes(self, expr, reverse_cost=False):
     array = expr.src if hasattr(expr, 'src') else expr.array
     child_ids = self.visit_children([array])
@@ -721,19 +721,19 @@ class AutomaticTiling(OptimizePass):
     else:
       tiling_types = (reverse_cost^self.nodes[child_ids[0]].tiling,)
       expr_node_ids = [self.cur_node_id]
-
+    
     for i in xrange(len(tiling_types)):
       self.nodes[self.cur_node_id] = self.node_type([expr], tiling_types[i], [], [])
-      self.add_edge(child_ids[-(reverse_cost^i)], self.cur_node_id, 0)
+      self.add_edge(child_ids[-(reverse_cost^i)], self.cur_node_id, 0)       
       self.cur_node_id += 1
     return expr_node_ids
-
+  
   def visit_TransposeExpr(self, expr):
     return self.visit_aligned_nodes(expr, reverse_cost=True)
-
+      
   def visit_ReshapeExpr(self, expr):
     return self.visit_aligned_nodes(expr, reverse_cost=True)
-
+  
   def visit_SliceExpr(self, expr):
     return self.visit_aligned_nodes(expr)
 
@@ -746,12 +746,12 @@ class AutomaticTiling(OptimizePass):
     child_ids = self.visit_children([expr.src])
     for child_id in child_ids: self.nodes[child_id].expr.append(expr)
     return child_ids
-
+  
   def visit_TileOpExpr(self, expr):
     child_ids = self.visit_children([expr.array])
     for child_id in child_ids: self.nodes[child_id].expr.append(expr)
     return child_ids
-
+  
   def generate_edges(self, s = 0):
     edges = []
     self.nodes[s].parents.sort(key=lambda x: reduce(operator.mul, self.nodes[x].expr[0].shape, 1))
@@ -761,7 +761,7 @@ class AutomaticTiling(OptimizePass):
         edges.extend(self.generate_edges(parent_id))
         self.visited_nodes.add(parent_id)
     return edges
-
+  
   def calc_tiling(self, expr):
     # add T node for graph
     if self.cur_node_id - 1 in self.split_nodes:
@@ -769,7 +769,7 @@ class AutomaticTiling(OptimizePass):
       self.add_edge(self.cur_node_id - 2, self.cur_node_id, 0)
       self.add_edge(self.cur_node_id - 1, self.cur_node_id, 0)
       self.cur_node_id += 1
-
+    
     # compute best tiling for all exprs
     self.visited_nodes = set()
     nodes = mincost_tiling(self.cur_node_id - 1, self.generate_edges(), self.split_nodes.items())
@@ -784,13 +784,13 @@ class AutomaticTiling(OptimizePass):
           if isinstance(cur_expr, (NdArrayExpr, ReduceExpr, DotExpr)) and len(cur_expr.shape) > 0:
             cur_expr.tile_hint = list(cur_expr.shape)
             cur_expr.tile_hint[node.tiling] = int(math.ceil(float(cur_expr.tile_hint[node.tiling]) / FLAGS.num_workers))
-
+      
     self.inited = False
     return expr
-
+    
   def visit_default(self, expr):
     if not self.inited: self.init(expr)
-
+    
     if hash(expr) in _tiled_exprlist or isinstance(expr, DistArray) or \
        isinstance(expr, (Val, AsArray)) and isinstance(expr.val, DistArray):
       # already partitioned array
@@ -799,12 +799,11 @@ class AutomaticTiling(OptimizePass):
       else:
         array = expr if isinstance(expr, DistArray) else expr.val
         tiling = array.tile_shape()[0] == array.shape[0]
-
       self.nodes[self.cur_node_id] = self.node_type([expr], tiling, [], [])
       expr_node_ids = [self.cur_node_id]
       self.add_edge(0, self.cur_node_id, 0)
       self.cur_node_id += 1
-
+        
     elif hash(expr) in self.expr_to_nodes:
       # cached expr
       expr_node_ids = self.expr_to_nodes[hash(expr)]
@@ -820,21 +819,21 @@ class AutomaticTiling(OptimizePass):
       expr_node_ids = [self.cur_node_id]
       for child_id in child_ids:
         self.add_edge(child_id, self.cur_node_id, 0)
-      self.cur_node_id += 1
-
+      self.cur_node_id += 1  
+      
     elif hasattr(self, 'visit_%s' % expr.typename()):
       expr_node_ids = getattr(self, 'visit_%s' % expr.typename())(expr)
-
+    
     else:
       util.log_debug("Skip expr:%s", expr.typename())
       expr_node_ids = []
-
+      
     # add T node for graph and compute the min cost flow
     if id(expr) == self.init_expr: return self.calc_tiling(expr)
-
+    
     self.expr_to_nodes[hash(expr)] = expr_node_ids
     return expr_node_ids
-
+      
 def apply_pass(klass, dag):
   if not getattr(FLAGS, 'opt_' + klass.name):
     util.log_debug('Pass %s disabled', klass.name)


### PR DESCRIPTION
Add a special case `add a new dimension` to reshape. Since this is the
most common use for reshape. This can help us get rid of `column fetch`
issue of reshape. But it doesn't fix the issue for all cases.
