### PR TITLE
Use atexit instead of signal handlers

### DIFF
--- a/spartan/__init__.py
+++ b/spartan/__init__.py
@@ -53,6 +53,7 @@ def initialize(argv=None):
 
   # Shutdown workers at exit; necessary for cluster mode.
   atexit.register(shutdown)
+  return CTX
 
 
 def shutdown():


### PR DESCRIPTION
I realized yesterday that instead of attaching a signal handler to manually stop the workers, we could just call shutdown `atexit`, when the main process is terminated. As you can see, this replaces 15 lines of code with only 3, while achieving the same effect.

Users can still shutdown their workers manually in an interactive python session by calling `spartan.shutdown()`, but they won't be able to use `ctl-c` (which I don't think is a huge drawback). They no longer need to though, because when Python / iPython exits, `shutdown` will be called.
