### PR TITLE
Update module path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -252,8 +252,8 @@ def setup_package():
                           "spartan/lib/libsimplerpc.so",
                           "spartan/lib/libbase.so"
                         ]),
-      Extension('spartan.expr.tiling',
-                sources=['spartan/expr/tiling.cc'],
+      Extension('spartan.expr.operator.tiling',
+                sources=['spartan/expr/operator/tiling.cc'],
                 language='c++',
                 extra_compile_args=["-std=c++0x"],
                 extra_link_args=["-std=c++11", "-fPIC"],

--- a/spartan/config.pyx
+++ b/spartan/config.pyx
@@ -215,8 +215,8 @@ def parse(argv):
   '''Parse configuration from flags and/or configuration file.'''
 
   # load flags defined in other modules (is there a better way to do this?)
-  import spartan.expr.local
-  import spartan.expr.optimize
+  import spartan.expr.operator.local
+  import spartan.expr.operator.optimize
   import spartan.cluster
   import spartan.util
 


### PR DESCRIPTION
Got following error msg:
```
nosetests tests/test_mathematics.py
Loading configuration from /home/gabrielwen/.config/spartan/spartan.ini
INFO 2015-02-23 16:29:09,628 server.cc:633 | beaker-20[1948] rpc::Server: started on 0.0.0.0:10072
INFO 2015-02-23 16:29:09,628 cluster.py:34 | beaker-20[1948] start_remote_worker: Starting worker 0:1 on host beaker-19
INFO 2015-02-23 16:29:09,737 cluster.py:34 | beaker-20[1948] start_remote_worker: Starting worker 1:2 on host beaker-18
INFO 2015-02-23 16:29:09,845 cluster.py:34 | beaker-20[1948] start_remote_worker: Starting worker 2:3 on host beaker-17
INFO 2015-02-23 16:29:09,953 cluster.py:34 | beaker-20[1948] start_remote_worker: Starting worker 3:4 on host beaker-16
Loading configuration from /home/gabrielwen/.config/spartan/spartan.ini
Loading configuration from /home/gabrielwen/.config/spartan/spartan.ini
ERROR 2015-02-23 16:29:13,955 server.cc:368 | beaker-20[1948] rpc::ServerConnection: no handler for rpc_id=0x4948039b
Loading configuration from /home/gabrielwen/.config/spartan/spartan.ini
INFO 2015-02-23 16:29:13,916 worker.cc:349 | beaker-19[21546] start worker pid 21546 at beaker-19:10073
INFO 2015-02-23 16:29:13,918 server.cc:633 | beaker-19[21546] rpc::Server: started on beaker-19:10073
ERROR 2015-02-23 16:29:13,956 worker.cc:65 | beaker-19[21546] Exit due to register message error:2.
INFO 2015-02-23 16:29:14,956 worker.cc:110 | beaker-19[21546] CWorker -1 shutdown. Exiting.
INFO 2015-02-23 16:29:14,956 worker.cc:366 | beaker-19[21546] Before clear
INFO 2015-02-23 16:29:15,058 worker.cc:371 | beaker-19[21546] Everything is cleared
INFO 2015-02-23 16:29:13,913 worker.cc:349 | beaker-16[31217] start worker pid 31217 at beaker-16:10073
INFO 2015-02-23 16:29:13,915 server.cc:633 | beaker-16[31217] rpc::Server: started on beaker-16:10073
ERROR 2015-02-23 16:29:13,955 worker.cc:65 | beaker-16[31217] Exit due to register message error:2.
INFO 2015-02-23 16:29:14,955 worker.cc:110 | beaker-16[31217] CWorker -1 shutdown. Exiting.
INFO 2015-02-23 16:29:14,955 worker.cc:366 | beaker-16[31217] Before clear
INFO 2015-02-23 16:29:15,058 worker.cc:371 | beaker-16[31217] Everything is cleared
INFO 2015-02-23 16:29:15,103 worker.cc:417 | beaker-19[21530] child pid 21546 finish!
Loading configuration from /home/gabrielwen/.config/spartan/spartan.ini
INFO 2015-02-23 16:29:15,128 worker.cc:417 | beaker-16[31201] child pid 31217 finish!
INFO 2015-02-23 16:29:14,932 worker.cc:349 | beaker-18[28230] start worker pid 28230 at beaker-18:10073
INFO 2015-02-23 16:29:14,934 server.cc:633 | beaker-18[28230] rpc::Server: started on beaker-18:10073
ERROR 2015-02-23 16:29:14,938 worker.cc:65 | beaker-18[28230] Exit due to register message error:2.
INFO 2015-02-23 16:29:15,938 worker.cc:110 | beaker-18[28230] CWorker -1 shutdown. Exiting.
INFO 2015-02-23 16:29:15,938 worker.cc:366 | beaker-18[28230] Before clear
INFO 2015-02-23 16:29:16,041 worker.cc:371 | beaker-18[28230] Everything is cleared
INFO 2015-02-23 16:29:16,105 worker.cc:417 | beaker-18[28214] child pid 28230 finish!
INFO 2015-02-23 16:29:15,113 worker.cc:349 | beaker-17[3120] start worker pid 3120 at beaker-17:10073
INFO 2015-02-23 16:29:15,115 server.cc:633 | beaker-17[3120] rpc::Server: started on beaker-17:10073
ERROR 2015-02-23 16:29:15,119 worker.cc:65 | beaker-17[3120] Exit due to register message error:2.
INFO 2015-02-23 16:29:16,119 worker.cc:110 | beaker-17[3120] CWorker -1 shutdown. Exiting.
INFO 2015-02-23 16:29:16,119 worker.cc:366 | beaker-17[3120] Before clear
INFO 2015-02-23 16:29:16,173 worker.cc:371 | beaker-17[3120] Everything is cleared
INFO 2015-02-23 16:29:16,234 worker.cc:417 | beaker-17[3104] child pid 3120 finish!
```