### PR TITLE
Use result instead of wait() when getting result from RPC.

### DIFF
--- a/spartan/expr/fio.py
+++ b/spartan/expr/fio.py
@@ -334,7 +334,7 @@ def _tile_mapper(tile_id, blob, tiles=None, user_fn=None, **kw):
     for ex, v in user_result:
       Assert.eq(ex.shape, v.shape, 'Bad shape from %s' % user_fn)
       result_tile = tile.from_data(v)
-      tile_id = ctx.create(result_tile).wait().tile_id
+      tile_id = ctx.create(result_tile).result.tile_id
       results.append((ex, tile_id))
 
   return LocalKernelResult(result=results)
@@ -362,7 +362,7 @@ def _partial_load(path, prefix, extents, iszip, ispickle):
                            hint=i)
 
   for ex in extents:
-    tiles[ex] = tiles[ex].wait().tile_id
+    tiles[ex] = tiles[ex].result.tile_id
 
   mapper = _load_mapper if not ispickle else _unpickle_mapper
   if ispickle:

--- a/spartan/expr/operator/filter.py
+++ b/spartan/expr/operator/filter.py
@@ -72,7 +72,7 @@ def _int_index_mapper(ex, src, idx, dst):
 
   #util.log_info('%s %s', output_ex.shape, np.array(output).shape)
   output_tile = tile.from_data(np.array(output))
-  tile_id = blob_ctx.get().create(output_tile).wait().tile_id
+  tile_id = blob_ctx.get().create(output_tile).result.tile_id
   return LocalKernelResult(result=[(output_ex, tile_id)])
 
 
@@ -93,7 +93,7 @@ def _bool_index_mapper(ex, src, idx):
   #util.log_info('\nVal: %s\n Mask: %s', val, mask)
   masked_val = np.ma.masked_array(val, mask)
   output_tile = tile.from_data(masked_val)
-  tile_id = blob_ctx.get().create(output_tile).wait().tile_id
+  tile_id = blob_ctx.get().create(output_tile).result.tile_id
   return LocalKernelResult(result=[(ex, tile_id)])
 
 

--- a/spartan/expr/operator/map.py
+++ b/spartan/expr/operator/map.py
@@ -83,7 +83,7 @@ def tile_mapper(ex, children, child_to_var, op):
 
   # make a new tile and return it
   result_tile = tile.from_data(result)
-  tile_id = blob_ctx.get().create(result_tile).wait().tile_id
+  tile_id = blob_ctx.get().create(result_tile).result.tile_id
 
   return LocalKernelResult(result=[(ex, tile_id)])
 

--- a/spartan/expr/operator/shuffle.py
+++ b/spartan/expr/operator/shuffle.py
@@ -90,7 +90,7 @@ def notarget_mapper(ex, array=None, map_fn=None, source=None, fn_kw=None):
     for ex, v in user_result:
       Assert.eq(ex.shape, v.shape, 'Bad shape from %s' % map_fn)
       result_tile = tile.from_data(v)
-      tile_id = blob_ctx.get().create(result_tile).wait().tile_id
+      tile_id = blob_ctx.get().create(result_tile).result.tile_id
       results.append((ex, tile_id))
 
   return LocalKernelResult(result=results, futures=None)


### PR DESCRIPTION
Use result instead of wait().