### PR TITLE
Fix psutil error and make travis built successfully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,11 @@ doc/_templates
 build/
 
 .ropeproject/
+
+#cython generated
+*.h
+*.c
+*.cpp
+
+#intellij stuff
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,23 @@ virtualenv:
   system_site_packages: true
 before_install:
    - sudo apt-get update -qq
-   - sudo apt-get install python-numpy python-scipy libzmq3-dev
-install: 
-  - LANG=C pip install pyzmq
-  - LANG=C pip install dsltools
-  - LANG=C pip install cython
-  - LANG=C pip install parakeet
-  - LANG=C pip install scikit-learn
-  - LANG=C pip install traits 
-  - LANG=C python setup.py develop
+install:
+   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
+   - sudo apt-get install -y -qq python-numpy python-scipy libzmq3-dev python-nose
+   - LANG=C pip install pyzmq    -q --user
+   - LANG=C pip install dsltools -q --user
+   - LANG=C pip install cython   -q --user
+   - LANG=C pip install parakeet -q --user
+   - LANG=C pip install scikit-learn -q --user
+   - LANG=C pip install traits   -q --user
+   - LANG=C python setup.py develop  --user
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
 script: nosetests -v --logging-level=INFO --logging-clear-handlers --logging-format='%(filename)s:%(lineno)s [%(funcName)s] %(message)s'

--- a/spartan/worker.py
+++ b/spartan/worker.py
@@ -61,7 +61,7 @@ class Worker(object):
     self._master = master
     self._running = True
     self._ctx = None
-    self.worker_status = core.WorkerStatus(psutil.TOTAL_PHYMEM, psutil.NUM_CPUS,
+    self.worker_status = core.WorkerStatus(psutil.virtual_memory().total, psutil.cpu_count(),
                                            psutil.virtual_memory().percent,
                                            psutil.cpu_percent(), 
                                            time.time(),


### PR DESCRIPTION
In file `spartan/worker.py`, `psutil.TOTAL_PHYMEM`and`psutil.NUM_CPUS` have been deprecated and already [removed](https://github.com/giampaolo/psutil/issues/451), which results to building failed. Therefore I create this PR.

BTW, I also modify the travis configuration to make c++11 supported in standard travis environment (Ubuntu 12.04 and gcc-4.6), the building result has been proven passing.
